### PR TITLE
Add local LLM integration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,23 @@ tracking chat messages. It can:
 - save/load the conversation to a JSONL file
 
 This is only a starting point for richer context handling.
+
+## Integrating with a local LLM
+
+The `examples/local_llm_example.py` script demonstrates pairing
+`ConversationMemory` with a small language model from the
+[Hugging Face Transformers](https://github.com/huggingface/transformers)
+library. To try it out:
+
+1. Install dependencies:
+   ```bash
+   pip install transformers torch
+   ```
+2. Run the example:
+   ```bash
+   python examples/local_llm_example.py
+   ```
+
+The script maintains conversation state and feeds the recent history to the
+local model on every turn, allowing the model to respond with awareness of the
+previous messages.

--- a/examples/local_llm_example.py
+++ b/examples/local_llm_example.py
@@ -1,0 +1,44 @@
+"""Example of integrating ConversationMemory with a local Hugging Face model.
+
+This script shows how to pair the ConversationMemory utility with a small
+language model that runs locally via the `transformers` library. The example
+uses the `distilgpt2` model for convenience, but any causal language model
+from the Hugging Face Hub (or a local path) can be substituted.
+"""
+
+from __future__ import annotations
+
+from memory import ConversationMemory
+
+from transformers import AutoModelForCausalLM, AutoTokenizer
+import torch
+
+
+def main() -> None:
+    """Run an interactive chat using ConversationMemory and a local model."""
+
+    model_name = "distilgpt2"
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModelForCausalLM.from_pretrained(model_name)
+
+    memory = ConversationMemory()
+
+    while True:
+        user_input = input("you: ")
+        if not user_input:
+            break
+        memory.add_message("user", user_input)
+
+        prompt = memory.to_prompt(limit=10) + "\nassistant:"
+        input_ids = tokenizer.encode(prompt, return_tensors="pt")
+        with torch.no_grad():
+            output_ids = model.generate(input_ids, max_new_tokens=50)
+        reply = tokenizer.decode(
+            output_ids[0][input_ids.shape[1]:], skip_special_tokens=True
+        ).strip()
+        print(f"assistant: {reply}")
+        memory.add_message("assistant", reply)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add an example script showing how to use ConversationMemory with a local Hugging Face model
- Document how to run the example and integrate a local LLM in the README

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688f2180f8ec8322be1e865f709a681a