### PR TITLE
Add entity-aware memory framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,23 @@ tracking chat messages. It can:
 - retrieve recent history for inclusion in prompts
 - save/load the conversation to a JSONL file
 
-This is only a starting point for richer context handling.
+ This is only a starting point for richer context handling.
+
+## Entity memory
+
+The `EntityMemory` class manages a separate `ConversationMemory` for each
+entity identifier, making it straightforward to track multiple characters or
+participants simultaneously. Each entity's messages are stored and retrieved
+independently.
+
+```python
+from memory import EntityMemory
+
+mem = EntityMemory()
+mem.add_message("wizard", "user", "Greetings")
+mem.add_message("dragon", "user", "Roar")
+print(mem.to_prompt("wizard"))  # -> "user: Greetings"
+```
 
 ## Integrating with a local LLM
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,4 +1,9 @@
-from memory import ConversationMemory
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from memory import ConversationMemory, EntityMemory
 
 
 def test_add_and_retrieve():
@@ -16,3 +21,20 @@ def test_persistence(tmp_path):
     mem.save(path)
     loaded = ConversationMemory.load(path)
     assert loaded.to_prompt() == "user: Hello"
+
+
+def test_entity_memory_add_and_retrieve():
+    mem = EntityMemory()
+    mem.add_message("hero", "user", "Hi")
+    mem.add_message("villain", "user", "Boo")
+    assert mem.to_prompt("hero") == "user: Hi"
+    assert mem.to_prompt("villain") == "user: Boo"
+
+
+def test_entity_memory_persistence(tmp_path):
+    path = tmp_path / "entity_mem.jsonl"
+    mem = EntityMemory()
+    mem.add_message("hero", "user", "Hello")
+    mem.save(path)
+    loaded = EntityMemory.load(path)
+    assert loaded.to_prompt("hero") == "user: Hello"


### PR DESCRIPTION
## Summary
- allow messages to store an optional entity identifier
- add `EntityMemory` to manage separate memories per entity with persistence helpers
- document and test entity-aware usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68904f4d45b483228c19a5ef478a4a64