### PR TITLE
docs: add example for tracking world entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ mem.add_message("dragon", "user", "Roar")
 print(mem.to_prompt("wizard"))  # -> "user: Greetings"
 ```
 
+To track locations or other non-character entities, use descriptive identifiers:
+
+```python
+mem.add_message("Coal Mine X", "status", "depleted")
+mem.add_message("Northwatch City", "status", "on high alert after raid")
+print(mem.to_prompt("Northwatch City"))
+```
+
+See `examples/world_state_example.py` for a complete demonstration.
+
 ## Integrating with a local LLM
 
 The `examples/local_llm_example.py` script demonstrates pairing

--- a/examples/world_state_example.py
+++ b/examples/world_state_example.py
@@ -1,0 +1,37 @@
+"""Example of tracking non-character entities with EntityMemory.
+
+This script demonstrates how locations or other world elements can be stored
+and queried just like character conversations. Each entity maintains its own
+message history, letting you keep notes on the state of places, items, or
+organizations in your game.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from memory import EntityMemory
+
+
+def main() -> None:
+    """Store and retrieve information about world entities."""
+
+    mem = EntityMemory()
+
+    # Track locations with arbitrary entity identifiers.
+    mem.add_message("Coal Mine X", "status", "depleted")
+    mem.add_message("Northwatch City", "status", "on high alert after raid")
+
+    # Retrieve the latest notes for each entity.
+    print("Mine:")
+    print(mem.to_prompt("Coal Mine X"))
+    print()
+    print("City:")
+    print(mem.to_prompt("Northwatch City"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document how EntityMemory can store notes for locations or other non-character entities
- add a runnable example script showing world state tracking

## Testing
- `pytest`
- `python examples/world_state_example.py`


------
https://chatgpt.com/codex/tasks/task_e_689052cc34c883229bd10cad08136ef7