### PR TITLE
Add batch message support for multiple entities

### DIFF
--- a/memory.py
+++ b/memory.py
@@ -115,7 +115,8 @@ class EntityMemory:
 
     Each entity identifier maps to its own :class:`ConversationMemory` instance.
     Messages are recorded per entity and can be saved/loaded from disk with the
-    entity information preserved.
+    entity information preserved. Use :meth:`add_messages` to record multi-entity
+    interactions efficiently.
     """
 
     def __init__(self) -> None:
@@ -127,12 +128,27 @@ class EntityMemory:
         """Append a message for ``entity``.
 
         A :class:`ConversationMemory` is created automatically for unknown
-        entities.
+        entities. For recording interactions with multiple entities, prefer
+        :meth:`add_messages`.
         """
 
         self._entities.setdefault(entity, ConversationMemory()).add_message(
             role, content, entity=entity
         )
+
+    def add_messages(self, items: Iterable[tuple[str, str, str]]) -> None:
+        """Append multiple messages for possibly different entities.
+
+        Parameters
+        ----------
+        items:
+            Iterable of ``(entity, role, content)`` tuples.
+
+        This is the recommended way to store multi-entity interactions.
+        """
+
+        for entity, role, content in items:
+            self.add_message(entity, role, content)
 
     # ------------------------------------------------------------------
     # access

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -38,3 +38,13 @@ def test_entity_memory_persistence(tmp_path):
     mem.save(path)
     loaded = EntityMemory.load(path)
     assert loaded.to_prompt("hero") == "user: Hello"
+
+
+def test_entity_memory_add_messages_multiple_entities():
+    mem = EntityMemory()
+    mem.add_messages([
+        ("hero", "user", "Hi"),
+        ("villain", "assistant", "Boo"),
+    ])
+    assert mem.to_prompt("hero") == "user: Hi"
+    assert mem.to_prompt("villain") == "assistant: Boo"


### PR DESCRIPTION
## Summary
- add `EntityMemory.add_messages` for batch recording of `(entity, role, content)` tuples
- update `EntityMemory` docs to recommend `add_messages`
- test multi-entity message ingestion in one call

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68919379bb808322af1cb4ec8ef2060d