### PR TITLE
Add rule-based interaction parser and example

### DIFF
--- a/action_parser.py
+++ b/action_parser.py
@@ -1,0 +1,59 @@
+"""Parse multi-entity interactions from free-form text.
+
+This module provides :func:`parse_interaction` which extracts structured
+``(entity, role, content)`` tuples from a block of text.  It currently uses a
+simple rule-based approach based on regular expressions. Each line of input is
+expected to follow the pattern ``"Entity (role): content"``.  Lines that do not
+match the pattern are ignored.
+
+The parser is intentionally lightweight so it can run in environments without
+network access or heavy dependencies.  To use a language model for more
+sophisticated parsing, replace the implementation of
+:func:`parse_interaction` with a call to your LLM of choice.  The function
+signature is designed to be compatible with such a swap; simply have the LLM
+produce JSON or another structured format and convert it to a list of tuples.
+
+Example
+-------
+>>> text = "Alice (user): Hello Bob\nBob (assistant): Hi Alice"
+>>> parse_interaction(text)
+[('Alice', 'user', 'Hello Bob'), ('Bob', 'assistant', 'Hi Alice')]
+
+"""
+from __future__ import annotations
+
+import re
+from typing import List, Tuple
+
+# Regular expression capturing ``Entity (role): content``
+_LINE_RE = re.compile(r"^\s*(?P<entity>[^():\n]+)\s*\((?P<role>[^)]+)\)\s*:\s*(?P<content>.+?)\s*$")
+
+
+def parse_interaction(text: str) -> List[Tuple[str, str, str]]:
+    """Parse ``text`` into ``(entity, role, content)`` tuples.
+
+    Parameters
+    ----------
+    text:
+        Multiline string describing interactions. Each line should be of the
+        form ``"Entity (role): content"``.
+
+    Returns
+    -------
+    list of tuple
+        A list of ``(entity, role, content)`` triples in the order they appear
+        in the input.
+    """
+
+    interactions: List[Tuple[str, str, str]] = []
+    for line in text.splitlines():
+        match = _LINE_RE.match(line)
+        if match:
+            interactions.append(
+                (
+                    match.group("entity").strip(),
+                    match.group("role").strip(),
+                    match.group("content").strip(),
+                )
+            )
+    return interactions

--- a/examples/multi_entity_example.py
+++ b/examples/multi_entity_example.py
@@ -1,0 +1,34 @@
+"""Example of parsing a multi-entity interaction script."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure the repository root is on the import path when running directly.
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from action_parser import parse_interaction
+from memory import EntityMemory
+
+
+def main() -> None:
+    """Parse a script and store messages for each entity."""
+
+    script = """
+    Alice (user): Hello Bob
+    Bob (assistant): Hi Alice
+    Narrator (system): The room is quiet.
+    """
+    interactions = parse_interaction(script)
+    mem = EntityMemory()
+    mem.add_messages(interactions)
+
+    for entity in ["Alice", "Bob", "Narrator"]:
+        print(f"{entity}:")
+        print(mem.to_prompt(entity))
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_action_parser.py
+++ b/tests/test_action_parser.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from action_parser import parse_interaction
+
+
+def test_parse_interaction_basic():
+    text = "Alice (user): Hi\nBob (assistant): Hello"
+    assert parse_interaction(text) == [
+        ("Alice", "user", "Hi"),
+        ("Bob", "assistant", "Hello"),
+    ]


### PR DESCRIPTION
## Summary
- add `parse_interaction` for extracting entity-role messages
- show parser feeding `EntityMemory.add_messages` in new example
- test interaction parser

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689194f45a308322922247b8eab54c43