### PR TITLE
Add Python script to interact with OpenAI-style language model

### DIFF
--- a/starta.py
+++ b/starta.py
@@ -1,0 +1,19 @@
+from openai import OpenAI
+
+client = OpenAI()
+
+
+def main():
+    response = client.chat.completions.create(
+        model="gpt-4o-mini",  # replace with your model
+        messages=[
+            {"role": "system", "content": "Du är en hjälpsam assistent."},
+            {"role": "user", "content": "Hej! Vad kan du göra?"}
+        ],
+        max_tokens=200,
+    )
+    print(response.choices[0].message["content"])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `starta.py` example script that sends a chat completion request and prints the response

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689aff125d28832eb1feefe3f102f61f