### PR TITLE
Add Momoa startup script for local gpt-oss-20b model

### DIFF
--- a/Momoa
+++ b/Momoa
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Interactive chat starter for a local gpt-oss-20b model.
+
+This script connects to a server implementing the OpenAI API
+specification at ``http://127.0.0.1:1234`` and uses the
+``gpt-oss-20b`` model. No manual configuration or API keys are
+required.
+"""
+
+from __future__ import annotations
+
+from memory import ConversationMemory
+from openai import OpenAI
+
+
+def main() -> None:
+    """Run an interactive chat with memory."""
+
+    client = OpenAI(base_url="http://127.0.0.1:1234/v1", api_key="not-needed")
+    memory = ConversationMemory()
+    system_prompt = "Du är en hjälpsam assistent."
+
+    print("Skriv ett meddelande (tom rad för att avsluta).")
+    while True:
+        user_input = input("you: ")
+        if not user_input:
+            break
+        memory.add_message("user", user_input)
+
+        messages = [{"role": "system", "content": system_prompt}]
+        for msg in memory.get_recent(limit=10):
+            messages.append({"role": msg.role, "content": msg.content})
+
+        response = client.chat.completions.create(
+            model="gpt-oss-20b", messages=messages, max_tokens=200
+        )
+        assistant_reply = response.choices[0].message["content"].strip()
+        print(f"assistant: {assistant_reply}")
+        memory.add_message("assistant", assistant_reply)
+
+
+if __name__ == "__main__":
+    main()

--- a/README.md
+++ b/README.md
@@ -58,3 +58,17 @@ library. To try it out:
 The script maintains conversation state and feeds the recent history to the
 local model on every turn, allowing the model to respond with awareness of the
 previous messages.
+
+## Quick start with `gpt-oss-20b`
+
+If you are running an OpenAI-compatible server exposing the
+`openai/gpt-oss-20b` model at `http://127.0.0.1:1234`, you can chat with it
+using the bundled **Momoa** script:
+
+```bash
+python Momoa
+```
+
+The script automatically connects to the local server and keeps track of the
+conversation using `ConversationMemory`, so no additional configuration or API
+keys are required.


### PR DESCRIPTION
## Summary
- document quick-start instructions for running a local gpt-oss-20b model
- add executable `Momoa` script that connects to a local OpenAI-compatible server with conversation memory

## Testing
- `pytest`
- `python Momoa` *(fails: ModuleNotFoundError: No module named 'openai')*
- `pip install openai -q` *(fails: Could not find a version that satisfies the requirement openai (from versions: none))*

------
https://chatgpt.com/codex/tasks/task_e_689b5200f80c832e8371f68735e59acf